### PR TITLE
Change a couple of functions to es6 arrow syntax

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function load_stache(node) {
     chrome.tabs.getAllInWindow(null, function(tabs) {
       chrome.tabs.create({});
-      var urls = tabs.map(function(tab) { return tab.url; });
+      var urls = tabs.map(tab => tab.url);
       for (var i in tabs) {
       	// some tabs should be ignored
       	// 1. ignore dublicate tabs
@@ -64,12 +64,11 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function unload_stache() {
-    _this = this;
-    chrome.bookmarks.getChildren(this.value, function(children) {
+    chrome.bookmarks.getChildren(this.value, (children) => {
        children.forEach(function(bookmark) {
          chrome.tabs.create({url: bookmark.url});
        });
-       chrome.bookmarks.removeTree(_this.value);
+       chrome.bookmarks.removeTree(this.value);
     });
   }
 }, false);


### PR DESCRIPTION
Pretty small tweak, but it a) makes the map function clear and b) removes the need to save the value of `this` inside `unload_stache` (although that last change may cause an issue with https://github.com/dngrhm/TabStache/pull/6 which fixes that `_this` to not be global.


